### PR TITLE
Call attention to the `en`-Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 Option | Result
 ------ | ------
-`\selectlanguage{english}` & Set language to english
-`\selectlanguage{ngerman}` & Set language to german
+`\selectlanguage{english}` | Set language to english
+`\selectlanguage{ngerman}` | Set language to german
 
 ### Options
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,10 @@
 
 Option | Result
 ------ | ------
-`\selectlanguage{english}` | Set language to english
+`\selectlanguage{english}` | Set language to english*
 `\selectlanguage{ngerman}` | Set language to german
+
+*You also should set the `en` Option. See below.
 
 ### Options
 

--- a/main.tex
+++ b/main.tex
@@ -13,7 +13,7 @@
 \myteacher{DSc MSc Deep Thought}
 \myyear{2017/18}
 \mydivision{Medientechnik, Systemtechnik}
-% \selectlanguage{english}			% Set language to english
+% \selectlanguage{english}			% Set language to english (Note: you also have to set the `en` Option like this: `\documentclass[minted,en]{thesis}`)
 % \selectlanguage{ngerman}			% Set language to german
 % \setcode{frame=single} 			% Add a frame to codes
 % \setcode{bgcolor=AlmostWhite}		% Add a background to codes (minted only)


### PR DESCRIPTION
The result "Set language to english" suggests that this is the only thing you have to do to change the document to english. If you do not also set the `en` option, generated text (like the captions of listings) will be in german.

This PR adds text to the corresponding comments in `main.tex` and updates the readme to clarify this.