### PR TITLE
Added alternating footer/header alignment

### DIFF
--- a/thesis.cls
+++ b/thesis.cls
@@ -148,10 +148,10 @@
 \pagestyle{fancy}\fancyhf{}
 
 \makeatletter
-\fancyhead[L]{\small \thetitle}
-\fancyhead[R]{\small \nouppercase{\leftmark}}
-\fancyfoot[L]{\small \if\relax\@currentauthor\relax\theauthors\else\@currentauthor\fi}
-\fancyfoot[R]{\small \thepage~/~{\lastpageref*{VeryLastPage}}}
+\fancyhead[LO,RE]{\small \thetitle}
+\fancyhead[RO,LE]{\small \nouppercase{\leftmark}}
+\fancyfoot[LO,RE]{\small \if\relax\@currentauthor\relax\theauthors\else\@currentauthor\fi}
+\fancyfoot[RO,LE]{\small \thepage~/~{\lastpageref*{VeryLastPage}}}
 \makeatother
 
 \renewcommand{\footrulewidth}{\headrulewidth}


### PR DESCRIPTION
the page numbers and chapter names are always on the outer edge of the pdf (book)
  even -> left
  odd -> right